### PR TITLE
Avoid double-converting local path to webview resource

### DIFF
--- a/src/commands/aksBestPractices/aksBestPractices.ts
+++ b/src/commands/aksBestPractices/aksBestPractices.ts
@@ -61,11 +61,10 @@ function getWebviewContent(
   webview: vscode.Webview
   ): string {
     const webviewClusterData = clusterdata?.properties;
-    const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-    const webviewCss = webview.asWebviewUri(styleUri);
-    const templateUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.html');
+    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.html');
     const data = {
-      cssuri: webviewCss,
+      cssuri: styleUri,
       name: webviewClusterData.metadata.name,
       description: webviewClusterData.metadata.description,
       portalUrl: getPortalUrl(clusterdata),

--- a/src/commands/aksCRUDDiagnostics/aksCRUDDiagnostics.ts
+++ b/src/commands/aksCRUDDiagnostics/aksCRUDDiagnostics.ts
@@ -61,11 +61,10 @@ function getWebviewContent(
   webview: vscode.Webview
   ): string {
     const webviewClusterData = clusterdata?.properties;
-    const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-    const webviewCss = webview.asWebviewUri(styleUri);
-    const templateUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.html');
+    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.html');
     const data = {
-      cssuri: webviewCss,
+      cssuri: styleUri,
       name: webviewClusterData.metadata.name,
       description: webviewClusterData.metadata.description,
       portalUrl: getPortalUrl(clusterdata),

--- a/src/commands/aksClusterProperties/aksClusterProperties.ts
+++ b/src/commands/aksClusterProperties/aksClusterProperties.ts
@@ -138,11 +138,10 @@ function getWebviewContent(
     webview: vscode.Webview
     ): string {
       const webviewClusterData = clusterdata?.properties;
-      const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-      const webviewCss = webview.asWebviewUri(styleUri);
-      const templateUri = getResourceUri(vscodeExtensionPath, 'aksclusterproperties', 'clusterproperties.html');
+      const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+      const templateUri = getResourceUri(webview, vscodeExtensionPath, 'aksclusterproperties', 'clusterproperties.html');
       const data = {
-        cssuri: webviewCss,
+        cssuri: styleUri,
         name: clusterdata.name,
         clusterData: webviewClusterData,
         clusterState: clusterState

--- a/src/commands/aksIdentitySecurity/aksIdentitySecurity.ts
+++ b/src/commands/aksIdentitySecurity/aksIdentitySecurity.ts
@@ -61,11 +61,10 @@ function getWebviewContent(
   webview: vscode.Webview
   ): string {
     const webviewClusterData = clusterdata?.properties;
-    const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-    const webviewCss = webview.asWebviewUri(styleUri);
-    const templateUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.html');
+    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.html');
     const data = {
-      cssuri: webviewCss,
+      cssuri: styleUri,
       name: webviewClusterData.metadata.name,
       description: webviewClusterData.metadata.description,
       portalUrl: getPortalUrl(clusterdata),

--- a/src/commands/aksKnownIssuesAvailabilityPerformance/aksKnownIssuesAvailabilityPerformance.ts
+++ b/src/commands/aksKnownIssuesAvailabilityPerformance/aksKnownIssuesAvailabilityPerformance.ts
@@ -61,11 +61,10 @@ function getWebviewContent(
   webview: vscode.Webview
   ): string {
     const webviewClusterData = clusterdata?.properties;
-    const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-    const webviewCss = webview.asWebviewUri(styleUri);
-    const templateUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.html');
+    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.html');
     const data = {
-      cssuri: webviewCss,
+      cssuri: styleUri,
       name: webviewClusterData.metadata.name,
       description: webviewClusterData.metadata.description,
       portalUrl: getPortalUrl(clusterdata),

--- a/src/commands/aksKubectlCommands/aksKubectlCommands.ts
+++ b/src/commands/aksKubectlCommands/aksKubectlCommands.ts
@@ -122,11 +122,10 @@ function getWebviewContent(
   vscodeExtensionPath: string,
   webview: vscode.Webview
   ): string {
-    const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-    const webviewCss = webview.asWebviewUri(styleUri);
-    const templateUri = getResourceUri(vscodeExtensionPath, 'aksKubectlCommand', 'akskubectlcommand.html');
+    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'aksKubectlCommand', 'akskubectlcommand.html');
     const data = {
-      cssuri: webviewCss,
+      cssuri: styleUri,
       name: commandRun,
       command: clusterdata.stdout,
     };

--- a/src/commands/aksNodeHealth/aksNodeHealth.ts
+++ b/src/commands/aksNodeHealth/aksNodeHealth.ts
@@ -61,11 +61,10 @@ function getWebviewContent(
   webview: vscode.Webview
   ): string {
     const webviewClusterData = clusterdata?.properties;
-    const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-    const webviewCss = webview.asWebviewUri(styleUri);
-    const templateUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.html');
+    const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+    const templateUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.html');
     const data = {
-      cssuri: webviewCss,
+      cssuri: styleUri,
       name: webviewClusterData.metadata.name,
       description: webviewClusterData.metadata.description,
       portalUrl: getPortalUrl(clusterdata),

--- a/src/commands/azureServiceOperators/helpers/azureservicehtmlhelper.ts
+++ b/src/commands/azureServiceOperators/helpers/azureservicehtmlhelper.ts
@@ -36,13 +36,12 @@ function getWebviewContent(
     getUserInput: boolean,
     webview: vscode.Webview
 ): string {
-    const styleUri = getResourceUri(aksExtensionPath, 'azureserviceoperator', 'azureserviceoperator.css');
-    const templateUri = getResourceUri(aksExtensionPath, 'azureserviceoperator', 'azureserviceoperator.html');
-    const webviewCss = webview.asWebviewUri(styleUri);
+    const styleUri = getResourceUri(webview, aksExtensionPath, 'azureserviceoperator', 'azureserviceoperator.css');
+    const templateUri = getResourceUri(webview, aksExtensionPath, 'azureserviceoperator', 'azureserviceoperator.html');
 
     const installHtmlResult = getOrganisedInstallResult(clustername, installationResponse);
     const data = {
-        cssuri: webviewCss,
+        cssuri: styleUri,
         name: clustername,
         mainMessage: installHtmlResult.mainMessage,
         resultLogs: installHtmlResult.logs,

--- a/src/commands/networkAndConnectivityDiagnostics/networkAndConnectivityDiagnostics.ts
+++ b/src/commands/networkAndConnectivityDiagnostics/networkAndConnectivityDiagnostics.ts
@@ -55,11 +55,10 @@ function getWebviewContent(
   webview: vscode.Webview
 ): string {
   const webviewClusterData = clusterdata?.properties;
-  const styleUri = getResourceUri(vscodeExtensionPath, 'common', 'detector.css');
-  const webviewCss = webview.asWebviewUri(styleUri);
-  const templateUri = getResourceUri(vscodeExtensionPath, 'networkconnectivity', 'networkConnectivity.html');
+  const styleUri = getResourceUri(webview, vscodeExtensionPath, 'common', 'detector.css');
+  const templateUri = getResourceUri(webview, vscodeExtensionPath, 'networkconnectivity', 'networkConnectivity.html');
   const data = {
-    cssuri: webviewCss,
+    cssuri: styleUri,
     name: webviewClusterData.metadata.name,
     description: webviewClusterData.metadata.description,
     portalUrl: getPortalUrl(clusterdata),

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -230,13 +230,12 @@ export function getSuccessWebviewContent(
     nodeNames: string[],
     webview: vscode.Webview
 ): string {
-    const styleUri = getResourceUri(aksExtensionPath, 'periscope', 'periscope.css');
-    const templateUri = getResourceUri(aksExtensionPath, 'periscope', 'success.html');
-    const webviewCss = webview.asWebviewUri(styleUri);
+    const styleUri = getResourceUri(webview, aksExtensionPath, 'periscope', 'periscope.css');
+    const templateUri = getResourceUri(webview, aksExtensionPath, 'periscope', 'success.html');
 
     const containerUrl = new URL(periscopeStorageInfo.containerName, periscopeStorageInfo.blobEndpoint);
     const data = {
-        cssuri: webviewCss,
+        cssuri: styleUri,
         name: clusterName,
         runId,
         nodeNames,
@@ -248,12 +247,11 @@ export function getSuccessWebviewContent(
 }
 
 export function getFailureWebviewContent(aksExtensionPath: string, clusterName: string, errorMessage: string, kustomizeConfig: KustomizeConfig, webview: vscode.Webview): string {
-    const styleUri = getResourceUri(aksExtensionPath, 'periscope', 'periscope.css');
-    const templateUri = getResourceUri(aksExtensionPath, 'periscope', 'failure.html');
-    const webviewCss = webview.asWebviewUri(styleUri);
+    const styleUri = getResourceUri(webview, aksExtensionPath, 'periscope', 'periscope.css');
+    const templateUri = getResourceUri(webview, aksExtensionPath, 'periscope', 'failure.html');
 
     const data = {
-        cssuri: webviewCss,
+        cssuri: styleUri,
         name: clusterName,
         error: errorMessage,
         config: kustomizeConfig
@@ -263,12 +261,11 @@ export function getFailureWebviewContent(aksExtensionPath: string, clusterName: 
 }
 
 export function getNoDiagSettingWebviewContent(aksExtensionPath: string, clusterName: string, webview: vscode.Webview): string {
-    const styleUri = getResourceUri(aksExtensionPath, 'periscope', 'periscope.css');
-    const templateUri = getResourceUri(aksExtensionPath, 'periscope', 'nodiagsetting.html');
-    const webviewCss = webview.asWebviewUri(styleUri);
+    const styleUri = getResourceUri(webview, aksExtensionPath, 'periscope', 'periscope.css');
+    const templateUri = getResourceUri(webview, aksExtensionPath, 'periscope', 'nodiagsetting.html');
 
     const data = {
-        cssuri: webviewCss,
+        cssuri: styleUri,
         name: clusterName
     };
 

--- a/src/commands/utils/webviews.ts
+++ b/src/commands/utils/webviews.ts
@@ -79,10 +79,9 @@ export function createWebView(viewType: string, title: string): vscode.WebviewPa
     return panel;
 }
 
-export function getResourceUri(vscodeExtensionPath: string, folder: string, filename: string): vscode.Uri {
-    return vscode.Uri
-        .file(path.join(vscodeExtensionPath, 'resources', 'webviews', folder, filename))
-        .with({ scheme: 'vscode-resource' });
+export function getResourceUri(webview: vscode.Webview, vscodeExtensionPath: string, folder: string, filename: string): vscode.Uri {
+    const onDiskPath = vscode.Uri.file(path.join(vscodeExtensionPath, 'resources', 'webviews', folder, filename));
+    return webview.asWebviewUri(onDiskPath);
 }
 
 export function getRenderedContent(templateUri: vscode.Uri, data: object): string {


### PR DESCRIPTION
The previous code was running `getResourceUri` and then doing `asWebviewUri` on the result of that, which resulted in invalid URIs.

This changes things so that `getResourceUri` runs `asWebviewUri` instead of the manual implementation (which now seems to be outdated).

Tested that this works both for retrieving local resource content from the file system (e.g. `getRenderedContent`) and from the webview itself (local css files). I.e. the previous implementation of `getResourceUri` is now redundant and is fully replaced by the one that uses `asWebviewUri`.