### PR TITLE
Move some code around

### DIFF
--- a/src/commands/aksClusterProperties/aksClusterProperties.ts
+++ b/src/commands/aksClusterProperties/aksClusterProperties.ts
@@ -5,7 +5,8 @@ import { ClusterARMResponse, determineClusterState, getAksClusterTreeItem, getCl
 import { getExtensionPath, longRunning }  from '../utils/host';
 import { Errorable, failed } from '../utils/errorable';
 import AksClusterTreeItem from '../../tree/aksClusterTreeItem';
-import { createWebView, delay, getRenderedContent, getResourceUri } from '../utils/webviews';
+import { createWebView, getRenderedContent, getResourceUri } from '../utils/webviews';
+import { sleep } from '../utils/sleep';
 
 export default async function aksClusterProperties(
     _context: IActionContext,
@@ -123,7 +124,7 @@ async function onReceivePerformOperations(
     }
     // This delay is deliberate for previous action to kick-in,
     // without delay if we call load data it is consistent to get old data from RP.
-    const clusterData = await longRunning(`Getting cluster data.`, async () => { await delay(10000); return getClusterData(cloudTarget); });
+    const clusterData = await longRunning(`Getting cluster data.`, async () => { await sleep(10000); return getClusterData(cloudTarget); });
     if (failed(clusterData)) {
       return { succeeded: false, error: clusterData.error };
     }

--- a/src/commands/periscope/helpers/periscopehelper.ts
+++ b/src/commands/periscope/helpers/periscopehelper.ts
@@ -13,7 +13,7 @@ import * as tmpfile from '../../utils/tempfile';
 import { getRenderedContent, getResourceUri } from '../../utils/webviews';
 import { combine, Errorable, failed } from '../../utils/errorable';
 import { invokeKubectlCommand } from '../../utils/kubectl';
-import { KustomizeConfig } from '../models/kustomizeConfig';
+import { KustomizeConfig } from '../models/config';
 import { ClusterFeatures } from '../models/clusterFeatures';
 import { ContainerServiceClient } from '@azure/arm-containerservice';
 import { getWindowsNodePoolKubernetesVersions } from '../../utils/clusters';

--- a/src/commands/periscope/models/config.ts
+++ b/src/commands/periscope/models/config.ts
@@ -4,3 +4,7 @@ export interface KustomizeConfig {
     releaseTag: string;
     imageVersion: string;
 }
+
+export interface KubeloginConfig {
+    releaseTag: string;
+ }

--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { combine, failed, Errorable } from './errorable';
-import { KustomizeConfig } from '../periscope/models/kustomizeConfig';
+import { KubeloginConfig, KustomizeConfig } from '../periscope/models/config';
 import * as semver from "semver";
 
 export function getKustomizeConfig(): Errorable<KustomizeConfig> {
@@ -35,6 +35,24 @@ export function getKustomizeConfig(): Errorable<KustomizeConfig> {
     return { succeeded: true, result: config };
 }
 
+export function getKubeloginConfig(): Errorable<KubeloginConfig> {
+    const kubeloginConfig = vscode.workspace.getConfiguration('azure.kubelogin');
+    const props = combine([getConfigValue(kubeloginConfig, 'releaseTag')]);
+ 
+    if (failed(props)) {
+       return {
+          succeeded: false,
+          error: `Failed to readazure.kubelogin configuration: ${props.error}`
+       };
+    }
+ 
+    const config = {
+       releaseTag: props.result[0]
+    };
+ 
+    return {succeeded: true, result: config};
+ }
+ 
 function getConfigValue(config: vscode.WorkspaceConfiguration, key: string): Errorable<string> {
     const value = config.get(key);
     if (value === undefined) {

--- a/src/commands/utils/helper/kubeloginDownload.ts
+++ b/src/commands/utils/helper/kubeloginDownload.ts
@@ -3,14 +3,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as download from '../download/download';
 import * as path from 'path';
-import { combine, Errorable, failed } from '../errorable';
+import { getKubeloginConfig } from '../config';
+import { Errorable, failed } from '../errorable';
 import { moveFile } from 'move-file';
 
 let kubeloginBinaryPath: string;
-
-interface KubeloginConfig {
-    releaseTag: string;
- }
 
 function baseInstallFolder(): string {
    return path.join(os.homedir(), `.vs-kubernetes/tools`);
@@ -120,40 +117,4 @@ function getKubeloginFileName() {
    }
 
    return kubeloginBinaryFile;
-}
-
-function getKubeloginConfig(): Errorable<KubeloginConfig> {
-   const kubeloginConfig = vscode.workspace.getConfiguration('azure.kubelogin');
-   const props = combine([getConfigValue(kubeloginConfig, 'releaseTag')]);
-
-   if (failed(props)) {
-      return {
-         succeeded: false,
-         error: `Failed to readazure.kubelogin configuration: ${props.error}`
-      };
-   }
-
-   const config = {
-      releaseTag: props.result[0]
-   };
-
-   return {succeeded: true, result: config};
-}
-
-function getConfigValue(
-   config: vscode.WorkspaceConfiguration,
-   key: string
-): Errorable<string> {
-   const value = config.get(key);
-   if (value === undefined) {
-      return {succeeded: false, error: `${key} not defined.`};
-   }
-   const result = value as string;
-   if (result === undefined) {
-      return {
-         succeeded: false,
-         error: `${key} value has type: ${typeof value}; expected string.`
-      };
-   }
-   return {succeeded: true, result: result};
 }

--- a/src/commands/utils/webviews.ts
+++ b/src/commands/utils/webviews.ts
@@ -105,7 +105,3 @@ htmlhandlers.registerHelper('startStopClusterValue', (value: any): string => {
     }
     return "Stop";
 });
-
-export function delay(ms: number) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
-}


### PR DESCRIPTION
@Tatsinnit - what do you reckon? Thought we could keep the config retrieval in one place? Also changed the periscope helper to re-use the `sleep` function you added.