### PR TITLE
Move more shared code into binaryDownloadHelper

### DIFF
--- a/src/commands/utils/helper/kubectlGadgetDownload.ts
+++ b/src/commands/utils/helper/kubectlGadgetDownload.ts
@@ -1,89 +1,62 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs';
 import * as os from 'os';
-import * as path from 'path';
 import { getKubectlGadgetConfig } from '../config';
 import { Errorable, failed } from '../errorable';
-import { longRunning } from '../host';
-import { downloadBinary, getBinaryExecutableFileName } from './binaryDownloadHelper';
-
-const GADGET_BINARY_NAME: string = "kubectl-gadget";
-
-function getBaseInstallFolder(): string {
-   return path.join(os.homedir(), `.vs-kubernetes/tools/kubectlgadget`);
-}
-
-function getKubectlGadgetBinaryFolder(releaseTag: string): string {
-   return path.join(getBaseInstallFolder(), releaseTag);
-}
-
-function getDownloadFolder(): string {
-   return path.join(getBaseInstallFolder(), "download");
-}
+import { getToolBinaryPath } from './binaryDownloadHelper';
 
 async function getLatestKubectlGadgetReleaseTag() {
-   const kubegadgetConfig = getKubectlGadgetConfig();
-   if (failed(kubegadgetConfig)) {
-      vscode.window.showErrorMessage(kubegadgetConfig.error);
-      return undefined;
-   }
+    const kubegadgetConfig = getKubectlGadgetConfig();
+    if (failed(kubegadgetConfig)) {
+        vscode.window.showErrorMessage(kubegadgetConfig.error);
+        return undefined;
+    }
 
-   return kubegadgetConfig.result.releaseTag;
-}
-
-function checkIfkubeGadgetBinaryExist(destinationFile: string): boolean {
-   return fs.existsSync(destinationFile);
+    return kubegadgetConfig.result.releaseTag;
 }
 
 export async function getKubectlGadgetBinaryPath(): Promise<Errorable<string>> {
-   // 0. Get latest release tag.
-   // 1: check if file already exist.
-   // 2: if not Download latest.
-   const releaseTag = await getLatestKubectlGadgetReleaseTag();
+    const releaseTag = await getLatestKubectlGadgetReleaseTag();
+    if (!releaseTag) {
+         return {succeeded: false, error: "Could not get latest release tag."};
+    }
 
-   if (!releaseTag) {
-      return {succeeded: false, error: "Could not get latest release tag."};
-   }
+    const archiveFilename = getArchiveFilename(releaseTag);
+    const downloadUrl = `https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${releaseTag}/${archiveFilename}`;
+    const pathToBinaryInArchive = getPathToBinaryInArchive();
 
-   const binaryFolder = getKubectlGadgetBinaryFolder(releaseTag);
+    // The plugin requires an '.exe' extension on Windows, but it doesn't have that in the archive
+    // so we can't simply extract it from the path within the archive.
+    const binaryFilename = getBinaryFilename();
 
-   const binaryFilePath = path.join(
-      binaryFolder,
-      getBinaryExecutableFileName(GADGET_BINARY_NAME)
-   );
-
-   if (checkIfkubeGadgetBinaryExist(binaryFilePath)) {
-      return {succeeded: true, result: binaryFilePath};
-   }
-
-   return await longRunning(`Downloading kubectl-gadget to ${binaryFilePath}.`, () => downloadKubectlGadget(binaryFilePath, releaseTag));
+    return await getToolBinaryPath("kubectl-gadget", releaseTag, downloadUrl, pathToBinaryInArchive, binaryFilename);
 }
 
-async function downloadKubectlGadget(
-   binaryFilePath: string, 
-   releaseTag: string
-   ): Promise<Errorable<string>> {
-   const downloadFolder = getDownloadFolder();
-   const downloadFileName = await getKubectlGadgetTarFileName();
+function getArchiveFilename(releaseTag: string) {
+    let architecture = os.arch();
+    let operatingSystem = os.platform().toLocaleLowerCase();
 
-   const kubectlgadgetDownloadUrl = `https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${releaseTag}/${downloadFileName}`;
+    if (architecture === 'x64') {
+        architecture = 'amd64';
+    }
 
-   const binaryFileDownloadResult = await downloadBinary(binaryFilePath, GADGET_BINARY_NAME, downloadFolder, kubectlgadgetDownloadUrl, downloadFileName);
-   return binaryFileDownloadResult;
+    if (operatingSystem === 'win32') {
+        operatingSystem = 'windows';
+    }
+
+    return `kubectl-gadget-${operatingSystem}-${architecture}-${releaseTag}.tar.gz`;
 }
 
-async function getKubectlGadgetTarFileName() {
-   let architecture = os.arch();
+function getPathToBinaryInArchive() {
+   return "kubectl-gadget";
+}
+
+function getBinaryFilename() {
    let operatingSystem = os.platform().toLocaleLowerCase();
-   const releaseTag = await getLatestKubectlGadgetReleaseTag();
-   
-   if (architecture === 'x64') {
-      architecture = 'amd64';
-   }
 
+   let extension = '';
    if (operatingSystem === 'win32') {
-      operatingSystem = 'win';
+       extension = '.exe';
    }
 
-   return `kubectl-gadget-${operatingSystem}-${architecture}-${releaseTag}.tar.gz`;
+   return `kubectl-gadget${extension}`;
 }


### PR DESCRIPTION
Also, take some tool-specific code out, and put it into the kubelogin and kubectl-gadget download files (avoiding switches based on tool, and keeping the messy tool-specific path code together.