### PR TITLE
Reorganization and fixes for multistep helper

### DIFF
--- a/src/multistep-helper/multistep-helper.ts
+++ b/src/multistep-helper/multistep-helper.ts
@@ -1,184 +1,187 @@
-import { QuickPickItem, window, Disposable, QuickInputButton, QuickInput, QuickInputButtons} from 'vscode';
+import * as vscode from 'vscode';
+import { QuickPickItem, window, Disposable, QuickInputButtons} from 'vscode';
+import { Errorable, failed } from '../commands/utils/errorable';
 
 // -------------------------------------------------------
 // Helper code that wraps the API for the multi-step case.
 // -------------------------------------------------------
 
-
-class InputFlowAction {
-    static back = new InputFlowAction();
-    static cancel = new InputFlowAction();
-    static resume = new InputFlowAction();
+enum InputFlowAction {
+    Back,
+    Cancel,
+    Next
 }
 
-type InputStep = (input: MultiStepInput) => Thenable<InputStep | void>;
-
-interface QuickPickParameters<T extends QuickPickItem> {
-    title: string;
-    step: number;
-    totalSteps: number;
-    items: T[];
-    activeItem?: T;
-    ignoreFocusOut?: boolean;
-    placeholder: string;
-    buttons?: QuickInputButton[];
-    shouldResume: () => Thenable<boolean>;
+// The result of a single 'step'
+type SingleStepOutput<T> = {
+    state: Partial<T>,
+    flowAction: InputFlowAction
 }
 
-interface InputBoxParameters {
+// The action that runs a single input step.
+type InputStep<T> = (state: Partial<T>, multiStepParams: MultiStepParameters, stepNumber: number) => Promise<SingleStepOutput<T>>;
+
+// Properties applicable to the entire multi-step input.
+interface MultiStepParameters {
     title: string;
-    step: number;
     totalSteps: number;
-    value: string;
-    prompt: string;
-    validate: (value: string) => Promise<string | undefined>;
-    buttons?: QuickInputButton[];
-    ignoreFocusOut?: boolean;
+}
+
+// Common properties applicable to a single step.
+interface StepParameters {
     placeholder?: string;
+    ignoreFocusOut?: boolean;
     shouldResume: () => Thenable<boolean>;
 }
 
-export class MultiStepInput {
+// Properties applicable specifically to a dropdown step.
+interface QuickPickParameters<TState, TItem extends QuickPickItem> extends StepParameters {
+    items: TItem[];
+    getActiveItem: (state: Partial<TState>) => TItem | void;
+    storeItem: (state: Partial<TState>, item: TItem) => Partial<TState>;
+}
 
-    static async run<T>(start: InputStep) {
-        const input = new MultiStepInput();
-        return input.stepThrough(start);
-    }
+// Properties applicable specifically to a text input step.
+interface InputBoxParameters<TState> extends StepParameters {
+    getValue: (state: Partial<TState>) => string | void;
+    prompt: string;
+    validate: (value: string) => Promise<Errorable<void>>;
+    storeValue: (state: Partial<TState>, value: string) => Partial<TState>;
+}
 
-    private current?: QuickInput;
-    private steps: InputStep[] = [];
+export async function runMultiStepInput<T>(title: string, state: Partial<T>, ...steps: [InputStep<T>, ...InputStep<T>[]]): Promise<T | void> {
+    let stepIndex = 0;
+    while (stepIndex >= 0 && stepIndex < steps.length) {
+        const step = steps[stepIndex];
+        const stepOutput = await step(state, { title, totalSteps: steps.length }, stepIndex + 1);
 
-    private async stepThrough<T>(start: InputStep) {
-        let step: InputStep | void = start;
-        while (step) {
-            this.steps.push(step);
-            if (this.current) {
-                this.current.enabled = false;
-                this.current.busy = true;
-            }
-            try {
-                step = await step(this);
-            } catch (err) {
-                if (err === InputFlowAction.back) {
-                    this.steps.pop();
-                    step = this.steps.pop();
-                } else if (err === InputFlowAction.resume) {
-                    step = this.steps.pop();
-                } else if (err === InputFlowAction.cancel) {
-                    step = undefined;
-                } else {
-                    throw err;
-                }
-            }
-        }
-        if (this.current) {
-            this.current.dispose();
+        state = stepOutput.state;
+        switch (stepOutput.flowAction) {
+            case InputFlowAction.Back:
+                stepIndex--;
+                break;
+            case InputFlowAction.Cancel:
+                stepIndex = -1;
+                break;
+            case InputFlowAction.Next:
+                stepIndex++;
+                break;
         }
     }
 
-    async showQuickPick<T extends QuickPickItem, P extends QuickPickParameters<T>>({ title, step, totalSteps, items, activeItem, ignoreFocusOut, placeholder, buttons, shouldResume }: P) {
-        const disposables: Disposable[] = [];
+    return stepIndex >= steps.length ? state as T : undefined;
+}
+
+export function createQuickPickStep<TState, TItem extends QuickPickItem>(params: QuickPickParameters<TState, TItem>): InputStep<TState> {
+    return async (state: Partial<TState>, multiStepParams: MultiStepParameters, stepNumber: number) => {
+        const input = window.createQuickPick<TItem>();
+        input.title = multiStepParams.title;
+        input.step = stepNumber;
+        input.totalSteps = multiStepParams.totalSteps;
+        input.ignoreFocusOut = params.ignoreFocusOut ?? false;
+        input.placeholder = params.placeholder;
+        input.items = params.items;
+        const activeItem = params.getActiveItem(state)
+        if (activeItem) {
+            input.activeItems = [activeItem];
+        }
+        input.buttons = stepNumber > 1 ? [QuickInputButtons.Back] : [];
+
+        let disposables: Disposable[] = [];
+        const inputPromise = new Promise<SingleStepOutput<TState>>(resolve => {
+            disposables = [
+                input.onDidTriggerButton(item => {
+                    if (item === QuickInputButtons.Back) {
+                        resolve({ state, flowAction: InputFlowAction.Back });
+                    } else {
+                        vscode.window.showErrorMessage("Unexpected button in QuickPick");
+                        resolve({ state, flowAction: InputFlowAction.Cancel });
+                    }
+                }),
+                input.onDidChangeSelection(items => {
+                    const newState = params.storeItem(state, items[0]);
+                    resolve({ state: newState, flowAction: InputFlowAction.Next });
+                }),
+                input.onDidHide(async () => {
+                    const resume = await params.shouldResume();
+                    const flowAction = resume ? InputFlowAction.Back : InputFlowAction.Cancel;
+                    resolve({ state, flowAction });
+                })
+            ];
+        });
+
         try {
-            return await new Promise<T | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
-                const input = window.createQuickPick<T>();
-                input.title = title;
-                input.step = step;
-                input.totalSteps = totalSteps;
-                input.ignoreFocusOut = ignoreFocusOut ?? false;
-                input.placeholder = placeholder;
-                input.items = items;
-                if (activeItem) {
-                    input.activeItems = [activeItem];
-                }
-                input.buttons = [
-                    ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
-                    ...(buttons || [])
-                ];
-                disposables.push(
-                    input.onDidTriggerButton(item => {
-                        if (item === QuickInputButtons.Back) {
-                            reject(InputFlowAction.back);
-                        } else {
-                            resolve(<any>item);
-                        }
-                    }),
-                    input.onDidChangeSelection(items => resolve(items[0])),
-                    input.onDidHide(() => {
-                        (async () => {
-                            reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel);
-                        })()
-                            .catch(reject);
-                    })
-                );
-                if (this.current) {
-                    this.current.dispose();
-                }
-                this.current = input;
-                this.current.show();
-            });
+            input.show();
+            return await inputPromise;
         } finally {
             disposables.forEach(d => d.dispose());
+            input.dispose();
         }
-    }
+    };
+}
 
-    async showInputBox<P extends InputBoxParameters>({ title, step, totalSteps, value, prompt, validate, buttons, ignoreFocusOut, placeholder, shouldResume }: P) {
-        const disposables: Disposable[] = [];
-        try {
-            return await new Promise<string | (P extends { buttons: (infer I)[] } ? I : never)>((resolve, reject) => {
-                const input = window.createInputBox();
-                input.title = title;
-                input.step = step;
-                input.totalSteps = totalSteps;
-                input.value = value || '';
-                input.prompt = prompt;
-                input.ignoreFocusOut = ignoreFocusOut ?? false;
-                input.placeholder = placeholder;
-                input.buttons = [
-                    ...(this.steps.length > 1 ? [QuickInputButtons.Back] : []),
-                    ...(buttons || [])
-                ];
-                let validating = validate('');
-                disposables.push(
-                    input.onDidTriggerButton(item => {
-                        if (item === QuickInputButtons.Back) {
-                            reject(InputFlowAction.back);
-                        } else {
-                            resolve(<any>item);
-                        }
-                    }),
-                    input.onDidAccept(async () => {
-                        const value = input.value;
-                        input.enabled = false;
-                        input.busy = true;
-                        if (!(await validate(value))) {
-                            resolve(value);
-                        }
+export function createInputBoxStep<TState>(params: InputBoxParameters<TState>): InputStep<TState> {
+    return async (state: Partial<TState>, multiStepParams: MultiStepParameters, stepNumber: number) => {
+        const input = window.createInputBox();
+        input.title = multiStepParams.title;
+        input.step = stepNumber;
+        input.totalSteps = multiStepParams.totalSteps;
+        input.value = params.getValue(state) || '';
+        input.prompt = params.prompt;
+        input.ignoreFocusOut = params.ignoreFocusOut ?? false;
+        input.placeholder = params.placeholder;
+        input.buttons = stepNumber > 1 ? [QuickInputButtons.Back] : [];
+
+        let disposables: Disposable[] = [];
+        const inputPromise = new Promise<SingleStepOutput<TState>>(resolve => {
+            let latestValidation: Promise<Errorable<void>> | null = null;
+            disposables = [
+                input.onDidTriggerButton(item => {
+                    if (item === QuickInputButtons.Back) {
+                        resolve({ state, flowAction: InputFlowAction.Back });
+                    } else {
+                        vscode.window.showErrorMessage("Unexpected button in InputBox");
+                        resolve({ state, flowAction: InputFlowAction.Cancel });
+                    }
+                }),
+                input.onDidAccept(async () => {
+                    const value = input.value;
+                    input.enabled = false;
+                    input.busy = true;
+                    const validationResult = await params.validate(value);
+                    if (failed(validationResult)) {
+                        input.validationMessage = validationResult.error;
                         input.enabled = true;
                         input.busy = false;
-                    }),
-                    input.onDidChangeValue(async text => {
-                        const current = validate(text);
-                        validating = current;
-                        const validationMessage = await current;
-                        if (current === validating) {
-                            input.validationMessage = validationMessage;
-                        }
-                    }),
-                    input.onDidHide(() => {
-                        (async () => {
-                            reject(shouldResume && await shouldResume() ? InputFlowAction.resume : InputFlowAction.cancel);
-                        })()
-                            .catch(reject);
-                    })
-                );
-                if (this.current) {
-                    this.current.dispose();
-                }
-                this.current = input;
-                this.current.show();
-            });
+                    } else {
+                        const newState = params.storeValue(state, value);
+                        resolve({ state: newState, flowAction: InputFlowAction.Next });
+                    }
+                }),
+                input.onDidChangeValue(async text => {
+                    const thisValidation = params.validate(text);
+                    latestValidation = thisValidation;
+                    const validationResult = await thisValidation;
+
+                    // Only display the validation result if this validation is the latest one.
+                    if (thisValidation === latestValidation) {
+                        input.validationMessage = failed(validationResult) ? validationResult.error : '';
+                    }
+                }),
+                input.onDidHide(async () => {
+                    const resume = await params.shouldResume();
+                    const flowAction = resume ? InputFlowAction.Back : InputFlowAction.Cancel;
+                    resolve({ state, flowAction });
+                })
+            ];
+        });
+
+        try {
+            input.show();
+            return await inputPromise;
         } finally {
             disposables.forEach(d => d.dispose());
+            input.dispose();
         }
-    }
+    };
 }


### PR DESCRIPTION
This changes the `multistep-helper` code so that input elements and event handlers are cleaned up more reliably.

Some other notes:
- The 'state' gathered by the inputs is separated from the parameters for displaying the inputs.
- `ResourceGroup` items are their own type with properties for name and location, to avoid needing regexes to parse out those values.
- 'Steps' are defined in advance, at the same level as each other, rather than subsequent steps being embedded in previous ones.
- Step numbers and total number of steps are calculated by the helper, so do not need to be provided.
- The `MultiStepInput` class is removed to simplify state handling (the `current` input element was particularly hard to reason about).