### PR TITLE
Streaming and updatable AI key

### DIFF
--- a/src/commands/utils/config.ts
+++ b/src/commands/utils/config.ts
@@ -28,6 +28,10 @@ export function getOpenAIConfig(): Errorable<OpenAIConfig> {
     return { succeeded: true, result: configresult };
 }
 
+export async function setOpenAIConfigApiKey(apiKey: string) {
+    await vscode.workspace.getConfiguration().update('aks.openai.apiKey', apiKey, vscode.ConfigurationTarget.Global, true);
+}
+
 export function getKustomizeConfig(): Errorable<KustomizeConfig> {
     const periscopeConfig = vscode.workspace.getConfiguration('aks.periscope');
     const props = combine([

--- a/src/commands/utils/helper/openaiHelper.ts
+++ b/src/commands/utils/helper/openaiHelper.ts
@@ -1,30 +1,35 @@
 import OpenAI from 'openai';
-import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat';
-import { failed } from '../errorable';
-import { getOpenAIConfig } from '../config';
-import * as vscode from 'vscode';
+import { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat';
+import { Errorable, getErrorMessage } from '../errorable';
+import { Observable, filter, from, map } from 'rxjs';
+import { Stream } from 'openai/streaming';
+import { OpenAIConfig } from './openaiConfig';
 
-export async function openaiHelper(error: string, command: string): Promise<string> {
-  const prompt = `I encountered the following error message when running 'kubectl ${command}': \n\n${error}\n\nWhat does this error mean, and how can I fix it?`
-  const body: ChatCompletionCreateParamsNonStreaming = {
-    messages: [{ role: 'user', content: prompt }],
-    model: 'gpt-3.5-turbo'
-  };
+export async function getOpenAIResult(config: OpenAIConfig, message: string): Promise<Errorable<Observable<string>>> {
+    const openai = new OpenAI({
+        apiKey: config.apiKey
+    });
 
-  const openaiConfig = getOpenAIConfig();
+    const body: ChatCompletionCreateParamsStreaming = {
+        messages: [{ role: 'user', content: message }],
+        model: 'gpt-3.5-turbo',
+        stream: true
+    };
 
-  if (failed(openaiConfig)) {
-    vscode.window.showInformationMessage(openaiConfig.error);
-    console.log(openaiConfig.error);
-    return ''
-  }
+    const options = { timeout: 30000 };
+    let responseStream: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;
+    try {
+        responseStream = await openai.chat.completions.create(body, options);
+    } catch (e) {
+        return { succeeded: false, error: getErrorMessage(e) };
+    }
 
-  const openai = new OpenAI({
-    apiKey: openaiConfig.result.apiKey
-  });
+    const response = from(responseStream).pipe(
+        map(chunk => chunk.choices[0].delta?.content || null),
+        filter(s => s !== null)) as Observable<string>; // Cast is safe because we're filtering out nulls.
 
-  const options = { timeout: 30000 };
-  const response = await openai.chat.completions.create(body, options);
-
-  return response.choices[0]?.message?.content || '';
+    return {
+        succeeded: true,
+        result: response
+    };
 }

--- a/src/panels/KubectlPanel.ts
+++ b/src/panels/KubectlPanel.ts
@@ -1,12 +1,14 @@
 import { Uri } from "vscode";
 import * as k8s from 'vscode-kubernetes-tools-api';
-import { failed } from "../commands/utils/errorable";
+import { Errorable, failed, getErrorMessage, succeeded } from "../commands/utils/errorable";
 import { MessageHandler, MessageSink } from "../webview-contract/messaging";
 import { BasePanel, PanelDataProvider } from "./BasePanel";
 import { invokeKubectlCommand } from "../commands/utils/kubectl";
-import { InitialState, PresetCommand, ToVsCodeMsgDef, ToWebViewMsgDef } from "../webview-contract/webviewDefinitions/kubectl";
-import { addKubectlCustomCommand, deleteKubectlCustomCommand } from "../commands/utils/config";
-import { openaiHelper } from "../commands/utils/helper/openaiHelper";
+import { AIKeyStatus, InitialState, PresetCommand, ToVsCodeMsgDef, ToWebViewMsgDef } from "../webview-contract/webviewDefinitions/kubectl";
+import { addKubectlCustomCommand, deleteKubectlCustomCommand, getOpenAIConfig, setOpenAIConfigApiKey } from "../commands/utils/config";
+import { getOpenAIResult } from "../commands/utils/helper/openaiHelper";
+import { OpenAIConfig } from "../commands/utils/helper/openaiConfig";
+import { Observable } from "rxjs";
 
 export class KubectlPanel extends BasePanel<"kubectl"> {
     constructor(extensionUri: Uri) {
@@ -15,6 +17,9 @@ export class KubectlPanel extends BasePanel<"kubectl"> {
 }
 
 export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
+    openAIConfig = getOpenAIConfig();
+    openAIKeyStatus = failed(this.openAIConfig) ? AIKeyStatus.Missing : AIKeyStatus.Unverified;
+
     constructor(
         readonly kubectl: k8s.APIAvailable<k8s.KubectlV1>,
         readonly kubeConfigFilePath: string,
@@ -37,7 +42,9 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         return {
             runCommandRequest: args => this._handleRunCommandRequest(args.command, webview),
             addCustomCommandRequest: args => this._handleAddCustomCommandRequest(args.name, args.command),
-            deleteCustomCommandRequest: args => this._handleDeleteCustomCommandRequest(args.name)
+            deleteCustomCommandRequest: args => this._handleDeleteCustomCommandRequest(args.name),
+            getAIKeyStatus: _args => this._handleGetAIKeyStatus(webview),
+            updateAIKeyRequest: args => this._handleUpdateAIKeyRequest(args.apiKey, webview)
         };
     }
 
@@ -45,42 +52,54 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
         const kubectlresult = await invokeKubectlCommand(this.kubectl, this.kubeConfigFilePath, command);
 
         if (failed(kubectlresult)) {
-            const aiMsg = await openaiHelper(kubectlresult.error, command);
-            const explanation = aiMsg ? `OpenAI GPT-3 Suggestion: ${aiMsg}` : null;
-            webview.postMessage({
-                command: "runCommandResponse", parameters: {
-                    output: null,
-                    errorMessage: kubectlresult.error,
-                    explanation
-                }
-            });
+            await this._sendResponse(webview, this.openAIConfig, command, null, kubectlresult.error);
             return;
         }
 
         // Sometimes there can be an error output even though the command returns a success status code.
         // This can happen when specifying an invalid namespace, for example.
         // For this reason we return stderr as well as stdout here.
+        await this._sendResponse(webview, this.openAIConfig, command, kubectlresult.result.stdout, kubectlresult.result.stderr);
+    }
 
-        if (kubectlresult.result.stderr) {
-            const aiMsg = await openaiHelper(kubectlresult.result.stderr, command);
-            const explanation = aiMsg ? `OpenAI GPT-3 Suggestion: ${aiMsg}` : null;
-            webview.postMessage({
-                command: "runCommandResponse", parameters: {
-                    output: null,
-                    errorMessage: kubectlresult.result.stderr,
-                    explanation
+    private async _sendResponse(
+        webview: MessageSink<ToWebViewMsgDef>,
+        openAIConfig: Errorable<OpenAIConfig>,
+        command: string,
+        output: string | null,
+        errorMessage: string | null
+    ) {
+        let aiResponse: Observable<string> | null = null;
+        if (errorMessage !== null) {
+            if (failed(openAIConfig)) {
+                this._updateAIKeyStatus(AIKeyStatus.Missing, null, webview);
+            } else {
+                const prompt = `I encountered the following error message when running 'kubectl ${command}': \n\n${errorMessage}\n\nWhat does this error mean, and how can I fix it?`
+                const response = await getOpenAIResult(openAIConfig.result, prompt);
+                if (failed(response)) {
+                    this._updateAIKeyStatus(AIKeyStatus.Invalid, openAIConfig.result.apiKey, webview);
+                } else {
+                    this._updateAIKeyStatus(AIKeyStatus.Valid, null, webview);
+                    aiResponse = response.result;
                 }
-            });
-            return;
+            }
         }
+
         webview.postMessage({
-            command: "runCommandResponse",
-            parameters: {
-                output: kubectlresult.result.stdout,
-                errorMessage: kubectlresult.result.stderr,
-                explanation: null
+            command: "runCommandResponse", parameters: {
+                output,
+                errorMessage
             }
         });
+
+        if (aiResponse !== null) {
+            webview.postMessage( {command: "startExplanation", parameters: undefined });
+            aiResponse.subscribe({
+                next: chunk => webview.postMessage({ command: "appendExplanation", parameters: {chunk} }),
+                error: err => webview.postMessage({ command: "errorStreamingExplanation", parameters: {error: getErrorMessage(err)} }),
+                complete: () => webview.postMessage({ command: "completeExplanation", parameters: undefined })
+            });
+        }
     }
 
     private async _handleAddCustomCommandRequest(name: string, command: string) {
@@ -89,5 +108,21 @@ export class KubectlDataProvider implements PanelDataProvider<"kubectl"> {
 
     private async _handleDeleteCustomCommandRequest(name: string) {
         await deleteKubectlCustomCommand(name);
+    }
+
+    private _handleGetAIKeyStatus(webview: MessageSink<ToWebViewMsgDef>) {
+        const invalidKey = succeeded(this.openAIConfig) && this.openAIKeyStatus === AIKeyStatus.Invalid ? this.openAIConfig.result.apiKey : null;
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus: this.openAIKeyStatus, invalidKey} });
+    }
+
+    private async _handleUpdateAIKeyRequest(apiKey: string, webview: MessageSink<ToWebViewMsgDef>) {
+        await setOpenAIConfigApiKey(apiKey);
+        this.openAIConfig = getOpenAIConfig();
+        this._updateAIKeyStatus(AIKeyStatus.Unverified, null, webview);
+    }
+
+    private _updateAIKeyStatus(keyStatus: AIKeyStatus, invalidKey: string | null, webview: MessageSink<ToWebViewMsgDef>) {
+        this.openAIKeyStatus = keyStatus;
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus, invalidKey} });
     }
 }

--- a/src/webview-contract/webviewDefinitions/kubectl.ts
+++ b/src/webview-contract/webviewDefinitions/kubectl.ts
@@ -35,7 +35,15 @@ export interface InitialState {
     customCommands: PresetCommand[]
 }
 
+export enum AIKeyStatus {
+    Missing,
+    Unverified,
+    Invalid,
+    Valid
+}
+
 export type ToVsCodeMsgDef = {
+    getAIKeyStatus: void,
     runCommandRequest: {
         command: string
     },
@@ -45,6 +53,9 @@ export type ToVsCodeMsgDef = {
     },
     deleteCustomCommandRequest: {
         name: string
+    },
+    updateAIKeyRequest: {
+        apiKey: string
     }
 };
 
@@ -52,7 +63,18 @@ export type ToWebViewMsgDef = {
     runCommandResponse: {
         output: string | null
         errorMessage: string | null
-        explanation: string | null
+    },
+    startExplanation: void,
+    errorStreamingExplanation: {
+        error: string
+    }
+    appendExplanation: {
+        chunk: string
+    },
+    completeExplanation: void,
+    updateAIKeyStatus: {
+        keyStatus: AIKeyStatus,
+        invalidKey: string | null
     }
 };
 

--- a/webview-ui/src/Kubectl/CommandOutput.tsx
+++ b/webview-ui/src/Kubectl/CommandOutput.tsx
@@ -1,24 +1,35 @@
 import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./Kubectl.module.css";
+import { OpenAIOutput } from "./OpenAIOutput";
+import { AIKeyStatus } from "../../../src/webview-contract/webviewDefinitions/kubectl";
 
 export interface CommandOutputProps {
     isCommandRunning: boolean
     output: string | null
     errorMessage: string | null
     explanation: string | null
+    isExplanationStreaming: boolean
+    aiKeyStatus: AIKeyStatus
+    invalidAIKey: string | null
+    onUpdateAPIKey: (apiKey: string) => void
 }
 
 export function CommandOutput(props: CommandOutputProps) {
     const hasOutput = props.output !== undefined;
     const hasError = props.errorMessage !== undefined;
-    const hasExplanation = props.explanation !== undefined;
 
     return (
     <>
         {props.isCommandRunning && <VSCodeProgressRing />}
         {hasOutput && <pre>{props.output}</pre>}
         {hasError && <pre className={styles.error}>{props.errorMessage}</pre>}
-        {hasExplanation && <pre className={styles.explanation}>{props.explanation}</pre>}
+        <OpenAIOutput
+            explanation={props.explanation}
+            isExplanationStreaming={props.isExplanationStreaming}
+            aiKeyStatus={props.aiKeyStatus}
+            invalidAIKey={props.invalidAIKey}
+            onUpdateAPIKey={props.onUpdateAPIKey}
+        />
     </>
     );
 }

--- a/webview-ui/src/Kubectl/CommandOutput.tsx
+++ b/webview-ui/src/Kubectl/CommandOutput.tsx
@@ -2,6 +2,8 @@ import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import styles from "./Kubectl.module.css";
 import { OpenAIOutput } from "./OpenAIOutput";
 import { AIKeyStatus } from "../../../src/webview-contract/webviewDefinitions/kubectl";
+import { EventHandlers } from "../utilities/state";
+import { UserMsgDef } from "./helpers/userCommands";
 
 export interface CommandOutputProps {
     isCommandRunning: boolean
@@ -11,7 +13,7 @@ export interface CommandOutputProps {
     isExplanationStreaming: boolean
     aiKeyStatus: AIKeyStatus
     invalidAIKey: string | null
-    onUpdateAPIKey: (apiKey: string) => void
+    userMessageHandlers: EventHandlers<UserMsgDef>
 }
 
 export function CommandOutput(props: CommandOutputProps) {
@@ -28,7 +30,7 @@ export function CommandOutput(props: CommandOutputProps) {
             isExplanationStreaming={props.isExplanationStreaming}
             aiKeyStatus={props.aiKeyStatus}
             invalidAIKey={props.invalidAIKey}
-            onUpdateAPIKey={props.onUpdateAPIKey}
+            userMessageHandlers={props.userMessageHandlers}
         />
     </>
     );

--- a/webview-ui/src/Kubectl/Kubectl.module.css
+++ b/webview-ui/src/Kubectl/Kubectl.module.css
@@ -115,3 +115,10 @@ pre.error {
 pre.explanation {
     color: var(--vscode-editor-foreground);
 }
+
+.labelTextButton {
+    display: grid;
+    grid-template-columns: 4rem 20rem 4rem;
+    grid-gap: 0.5rem;
+    align-items: center;
+}

--- a/webview-ui/src/Kubectl/OpenAIOutput.tsx
+++ b/webview-ui/src/Kubectl/OpenAIOutput.tsx
@@ -3,6 +3,8 @@ import styles from "./Kubectl.module.css";
 import { FormEvent, useState } from "react";
 import { getWebviewMessageContext } from "../utilities/vscode";
 import { AIKeyStatus } from "../../../src/webview-contract/webviewDefinitions/kubectl";
+import { EventHandlers } from "../utilities/state";
+import { UserMsgDef } from "./helpers/userCommands";
 
 type ChangeEvent = Event | FormEvent<HTMLElement>;
 
@@ -11,7 +13,7 @@ export interface OpenAIOutputProps {
     isExplanationStreaming: boolean
     aiKeyStatus: AIKeyStatus
     invalidAIKey: string | null
-    onUpdateAPIKey: (apiKey: string) => void
+    userMessageHandlers: EventHandlers<UserMsgDef>
 }
 
 export function OpenAIOutput(props: OpenAIOutputProps) {
@@ -26,7 +28,7 @@ export function OpenAIOutput(props: OpenAIOutputProps) {
 
     function handleUpdateClick() {
         vscode.postMessage({ command: "updateAIKeyRequest", parameters: {apiKey} });
-        props.onUpdateAPIKey(apiKey);
+        props.userMessageHandlers.onSetAPIKeySaved();
     }
 
     const canUpdate = apiKey && apiKey.trim() && apiKey.trim() !== props.invalidAIKey;
@@ -38,9 +40,11 @@ export function OpenAIOutput(props: OpenAIOutputProps) {
                 <div>
                     {props.aiKeyStatus === AIKeyStatus.Invalid && <p>OpenAI API Key is invalid</p>}
                     {props.aiKeyStatus === AIKeyStatus.Missing && <p>OpenAI API Key is not set</p>}
-                    <label htmlFor="api-key-input">API Key:</label>
-                    <VSCodeTextField id="api-key-input" value={apiKey} onInput={handleAPIKeyChange} />
-                    <VSCodeButton disabled={!canUpdate} onClick={handleUpdateClick}>{props.invalidAIKey ? 'Update' : 'Set'}</VSCodeButton>
+                    <div className={styles.labelTextButton}>
+                        <label htmlFor="api-key-input">API Key:</label>
+                        <VSCodeTextField id="api-key-input" value={apiKey} onInput={handleAPIKeyChange} />
+                        <VSCodeButton disabled={!canUpdate} onClick={handleUpdateClick}>{props.invalidAIKey ? 'Update' : 'Set'}</VSCodeButton>
+                    </div>
                 </div>
             )}
             {props.explanation && <pre className={styles.explanation}>{props.explanation}</pre>}

--- a/webview-ui/src/Kubectl/OpenAIOutput.tsx
+++ b/webview-ui/src/Kubectl/OpenAIOutput.tsx
@@ -1,0 +1,49 @@
+import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+import styles from "./Kubectl.module.css";
+import { FormEvent, useState } from "react";
+import { getWebviewMessageContext } from "../utilities/vscode";
+import { AIKeyStatus } from "../../../src/webview-contract/webviewDefinitions/kubectl";
+
+type ChangeEvent = Event | FormEvent<HTMLElement>;
+
+export interface OpenAIOutputProps {
+    explanation: string | null
+    isExplanationStreaming: boolean
+    aiKeyStatus: AIKeyStatus
+    invalidAIKey: string | null
+    onUpdateAPIKey: (apiKey: string) => void
+}
+
+export function OpenAIOutput(props: OpenAIOutputProps) {
+    const vscode = getWebviewMessageContext<"kubectl">();
+
+    const [apiKey, setApiKey] = useState<string>("");
+
+    function handleAPIKeyChange(e: ChangeEvent) {
+        const input = e.currentTarget as HTMLInputElement;
+        setApiKey(input.value);
+    }
+
+    function handleUpdateClick() {
+        vscode.postMessage({ command: "updateAIKeyRequest", parameters: {apiKey} });
+        props.onUpdateAPIKey(apiKey);
+    }
+
+    const canUpdate = apiKey && apiKey.trim() && apiKey.trim() !== props.invalidAIKey;
+    const needsNewAIKey = props.aiKeyStatus === AIKeyStatus.Missing || props.aiKeyStatus === AIKeyStatus.Invalid;
+
+    return (
+        <>
+            {needsNewAIKey && (
+                <div>
+                    {props.aiKeyStatus === AIKeyStatus.Invalid && <p>OpenAI API Key is invalid</p>}
+                    {props.aiKeyStatus === AIKeyStatus.Missing && <p>OpenAI API Key is not set</p>}
+                    <label htmlFor="api-key-input">API Key:</label>
+                    <VSCodeTextField id="api-key-input" value={apiKey} onInput={handleAPIKeyChange} />
+                    <VSCodeButton disabled={!canUpdate} onClick={handleUpdateClick}>{props.invalidAIKey ? 'Update' : 'Set'}</VSCodeButton>
+                </div>
+            )}
+            {props.explanation && <pre className={styles.explanation}>{props.explanation}</pre>}
+        </>
+    )
+}

--- a/webview-ui/src/Kubectl/helpers/state.ts
+++ b/webview-ui/src/Kubectl/helpers/state.ts
@@ -1,0 +1,58 @@
+import { AIKeyStatus, PresetCommand, ToWebViewMsgDef, presetCommands } from "../../../../src/webview-contract/webviewDefinitions/kubectl"
+import { StateMessageHandler, chainStateUpdaters, toStateUpdater } from "../../utilities/state"
+import { UserMsgDef } from "./userCommands"
+
+export interface KubectlState {
+    initializationStarted: boolean
+    allCommands: PresetCommand[]
+    selectedCommand: string | null
+    isCommandRunning: boolean
+    output: string | null
+    errorMessage: string | null
+    explanation: string | null
+    isExplanationStreaming: boolean
+    aiKeyStatus: AIKeyStatus
+    invalidAIKey: string | null
+    isSaveDialogShown: boolean
+}
+
+export function createState(customCommands: PresetCommand[]): KubectlState {
+    return {
+        initializationStarted: false,
+        allCommands: [...presetCommands, ...customCommands],
+        selectedCommand: null,
+        isCommandRunning: false,
+        output: null,
+        errorMessage: null,
+        explanation: null,
+        isExplanationStreaming: false,
+        aiKeyStatus: AIKeyStatus.Unverified,
+        invalidAIKey: null,
+        isSaveDialogShown: false
+    };
+}
+
+export const vscodeMessageHandler: StateMessageHandler<ToWebViewMsgDef, KubectlState> = {
+    runCommandResponse: (state, args) => ({...state, output: args.output, errorMessage: args.errorMessage, explanation: null, isCommandRunning: false}),
+    startExplanation: (state, _args) => ({...state, isExplanationStreaming: true}),
+    errorStreamingExplanation: (state, args) => {
+        console.error(args.error);
+        return state;
+    },
+    appendExplanation: (state, args) => ({...state, explanation: (state.explanation || "") + args.chunk}),
+    completeExplanation: (state, _args) => ({...state, isExplanationStreaming: false}),
+    updateAIKeyStatus: (state, args) => ({...state, aiKeyStatus: args.keyStatus, invalidAIKey: args.invalidKey})
+}
+
+export const userMessageHandler: StateMessageHandler<UserMsgDef, KubectlState> = {
+    setInitializing: (state, _args) => ({...state, initializationStarted: true}),
+    setSelectedCommand: (state, args) => ({...state, selectedCommand: args.command, output: null, errorMessage: null, explanation: null}),
+    setAllCommands: (state, args) => ({...state, allCommands: args.allCommands}),
+    setCommandRunning: (state, _args) => ({...state, isCommandRunning: true, output: null, errorMessage: null, explanation: null}),
+    setSaveDialogVisibility: (state, args) => ({...state, isSaveDialogShown: args.shown}),
+    setAPIKeySaved: (state, _args) => ({...state, aiKeyStatus: AIKeyStatus.Unverified, invalidAIKey: null})
+}
+
+export const updateState = chainStateUpdaters(
+    toStateUpdater(vscodeMessageHandler),
+    toStateUpdater(userMessageHandler));

--- a/webview-ui/src/Kubectl/helpers/userCommands.ts
+++ b/webview-ui/src/Kubectl/helpers/userCommands.ts
@@ -1,0 +1,19 @@
+import { Message } from "../../../../src/webview-contract/messaging"
+import { PresetCommand } from "../../../../src/webview-contract/webviewDefinitions/kubectl"
+
+export type UserMsgDef = {
+    setInitializing: void,
+    setSelectedCommand: {
+        command: string
+    },
+    setAllCommands: {
+        allCommands: PresetCommand[]
+    },
+    setCommandRunning: void,
+    setSaveDialogVisibility: {
+        shown: boolean
+    },
+    setAPIKeySaved: void
+}
+
+export type UserMessage = Message<UserMsgDef>;

--- a/webview-ui/src/manualTest/kubectlTests.tsx
+++ b/webview-ui/src/manualTest/kubectlTests.tsx
@@ -1,5 +1,5 @@
 import { MessageHandler } from "../../../src/webview-contract/messaging";
-import { CommandCategory, InitialState, PresetCommand, ToVsCodeMsgDef } from "../../../src/webview-contract/webviewDefinitions/kubectl";
+import { AIKeyStatus, CommandCategory, InitialState, PresetCommand, ToVsCodeMsgDef } from "../../../src/webview-contract/webviewDefinitions/kubectl";
 import { Kubectl } from "../Kubectl/Kubectl";
 import { Scenario } from "../utilities/manualTest";
 import { getTestVscodeMessageContext } from "../utilities/vscode";
@@ -8,6 +8,9 @@ const customCommands: PresetCommand[] = [
     {name: "Test 1", command: "get things", category: CommandCategory.Custom},
     {name: "Test 2", command: "get other things", category: CommandCategory.Custom}
 ];
+
+let apiKey: string | null = null;
+let apiKeyStatus = apiKey ? AIKeyStatus.Unverified : AIKeyStatus.Missing;
 
 export function getKubectlScenarios() {
     const clusterName = "test-cluster";
@@ -22,7 +25,9 @@ export function getKubectlScenarios() {
         return {
             runCommandRequest: args => handleRunCommandRequest(args.command, succeeding),
             addCustomCommandRequest: _ => undefined,
-            deleteCustomCommandRequest: _ => undefined
+            deleteCustomCommandRequest: _ => undefined,
+            getAIKeyStatus: _ => handleGetAIKeyStatus(),
+            updateAIKeyRequest: args => handleUpdateAIKeyRequest(args.apiKey)
         }
     }
 
@@ -33,20 +38,59 @@ export function getKubectlScenarios() {
                 command: "runCommandResponse",
                 parameters: {
                     output: Array.from({length: 20}, (_, i) => `This is the output of "kubectl ${command}" line ${i + 1}`).join('\n'),
-                    errorMessage: "",
-                    explanation: null
+                    errorMessage: ""
                 }
             });
         } else {
+            const explanation = "And here's a natural language explanation of what went wrong.";
+            let canStream = false;
+            if (apiKey === "valid") {
+                canStream = true;
+                updateAIKeyStatus(AIKeyStatus.Valid, null);
+            } else if (!apiKey) {
+                updateAIKeyStatus(AIKeyStatus.Missing, null);
+            } else {
+                updateAIKeyStatus(AIKeyStatus.Invalid, apiKey);
+            }
+
             webview.postMessage({
                 command: "runCommandResponse",
                 parameters: {
                     output: null,
-                    errorMessage: "Something went wrong and this is the error.",
-                    explanation: "And here's a natural language explanation of what went wrong."
+                    errorMessage: "Something went wrong and this is the error."
                 }
             });
+
+            if (canStream) {
+                for (const word of explanation.split(" ").map((w, i) => `${i > 0 ? ' ': ''}${w}`)) {
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                    webview.postMessage({
+                        command: "appendExplanation",
+                        parameters: {
+                            chunk: word
+                        }
+                    });
+                }
+                await new Promise(resolve => setTimeout(resolve, 100));
+                webview.postMessage({
+                    command: "completeExplanation",
+                    parameters: undefined
+                });
+            }
         }
+    }
+
+    function handleGetAIKeyStatus() {
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus: apiKeyStatus, invalidKey: null} });
+    }
+
+    function handleUpdateAIKeyRequest(newApiKey: string) {
+        apiKey = newApiKey;
+    }
+
+    function updateAIKeyStatus(keyStatus: AIKeyStatus, invalidKey: string | null) {
+        apiKeyStatus = keyStatus;
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus, invalidKey} });
     }
 
     return [

--- a/webview-ui/src/manualTest/kubectlTests.tsx
+++ b/webview-ui/src/manualTest/kubectlTests.tsx
@@ -81,11 +81,12 @@ export function getKubectlScenarios() {
     }
 
     function handleGetAIKeyStatus() {
-        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus: apiKeyStatus, invalidKey: null} });
+        webview.postMessage({ command: "updateAIKeyStatus", parameters: {keyStatus: apiKeyStatus, invalidKey: apiKeyStatus === AIKeyStatus.Invalid ? apiKey : null} });
     }
 
     function handleUpdateAIKeyRequest(newApiKey: string) {
         apiKey = newApiKey;
+        updateAIKeyStatus(AIKeyStatus.Unverified, null);
     }
 
     function updateAIKeyStatus(keyStatus: AIKeyStatus, invalidKey: string | null) {


### PR DESCRIPTION
Returns kubectl result as soon as the command has executed, and displays the AI-generated explanation asynchronously.

If the user has not set their OpenAI key, it will display a field to set it. If the key doesn't work, it will display another to update it. See screenshots below.

Also needed to move state into a separate file and use a reducer for updating it. Reason: when a state object within a component is updated multiple times in short succession, subsequent updates can be applied to a stale version of the state, resulting in superseded values being resurrected. The [reducer pattern](https://react.dev/reference/react/useReducer) avoids this.

<img width="526" alt="image" src="https://github.com/Tatsinnit/vscode-aks-tools/assets/1817696/8847ab57-05b3-4b43-938d-f442642047ca">

<img width="395" alt="image" src="https://github.com/Tatsinnit/vscode-aks-tools/assets/1817696/37230fab-db22-4d16-8694-ea30f4ccc559">

